### PR TITLE
Merge blockworks octane with personal octane

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,12 +26,12 @@
     "dependencies": {
         "@orca-so/whirlpools-sdk": "^0.5.0",
         "@project-serum/anchor": "^0.25.0",
-        "@solana/spl-token": "^0.2.0",
+        "@solana/spl-token": "0.3.7",
         "@solana/web3.js": "^1.34.0",
+        "axios": "^0.27.2",
         "bs58": "^4.0.1",
         "cache-manager": "^3.6.0",
-        "encoding": "^0.1.13",
-        "axios": "^0.27.2"
+        "encoding": "^0.1.13"
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "license": "Apache-2.0",
     "types": "dist/types/index.d.ts",
     "module": "dist/index.js",
+    "main": "dist/index.js",
     "files": [
         "dist",
         "src"

--- a/packages/core/src/payer-utils/jupiter.ts
+++ b/packages/core/src/payer-utils/jupiter.ts
@@ -8,12 +8,12 @@ export type TokenPriceInfo = {
     vsToken: string;
     vsTokenSymbol: string;
     price: number;
-}
+};
 
 type TokenPriceInfoResponse = {
     data: TokenPriceInfo;
     timeTaken: number;
-}
+};
 
 export type Route = {
     inAmount: number;
@@ -24,7 +24,7 @@ export type Route = {
     swapMode: string;
     priceImpactPct: number;
     marketInfos: RouteMarketInfo[];
-}
+};
 
 export type RouteMarketInfo = {
     id: string;
@@ -39,42 +39,42 @@ export type RouteMarketInfo = {
     priceImpactPct: number;
     minInAmount?: number;
     minOutAmount?: number;
-}
+};
 
 export type RouteFee = {
     amount: number;
     mint: string;
     pct: number;
-}
+};
 
 type RoutesResponse = {
     data: Route[];
     timeTaken: number;
     contextSlot: string;
-}
+};
 
 export type SwapTransactions = {
     setup: Transaction | null;
     swap: Transaction | null;
     cleanup: Transaction | null;
-}
+};
 
 type SwapTransactionsResponse = {
     setupTransaction: string | null;
     swapTransaction: string | null;
     cleanupTransaction: string | null;
-}
+};
 
 export async function getPopularTokens(count: number, excludeNative = true): Promise<PublicKey[]> {
     const response = await axios.get('https://cache.jup.ag/top-tokens');
     const mints = response.data.map((mint: string) => new PublicKey(mint)) as PublicKey[];
-    const filteredMints = excludeNative ? mints.filter(value => !value.equals(NATIVE_MINT)) : mints;
+    const filteredMints = excludeNative ? mints.filter((value) => !value.equals(NATIVE_MINT)) : mints;
     return filteredMints.slice(0, count);
 }
 
 export async function getTokenToNativePriceInfo(mint: PublicKey): Promise<TokenPriceInfo> {
     const priceInfoResponse = (
-        await axios.get('https://price.jup.ag/v1/price', {params: {id: 'SOL', vsToken: mint.toBase58()}})
+        await axios.get('https://price.jup.ag/v1/price', { params: { id: 'SOL', vsToken: mint.toBase58() } })
     ).data as TokenPriceInfoResponse;
     return priceInfoResponse.data;
 }
@@ -91,30 +91,30 @@ export async function getRoutes(
         amount: amount,
         slippage: slippage,
     };
-    const routesResponse = (await axios.get(
-        'https://quote-api.jup.ag/v1/quote', { params }
-    )).data as RoutesResponse;
+    const routesResponse = (await axios.get('https://quote-api.jup.ag/v1/quote', { params })).data as RoutesResponse;
     return routesResponse.data;
 }
 
 export async function getSwapTransactions(wallet: PublicKey, route: Route): Promise<SwapTransactions> {
-    const decodeTransactionOrNull = (serialized: string | null) => (
-        serialized !== null ? Transaction.from(Buffer.from(serialized, 'base64')) : null
-    );
+    const decodeTransactionOrNull = (serialized: string | null) =>
+        serialized != null ? Transaction.from(Buffer.from(serialized, 'base64')) : null;
 
     const response = (
-        await axios.post('https://quote-api.jup.ag/v1/swap', {
-            route,
-            userPublicKey: wallet.toString(),
-            wrapUnwrapSOL: true,
-        }, {
-            headers: { 'Content-Type': 'application/json' }
-        })
+        await axios.post(
+            'https://quote-api.jup.ag/v1/swap',
+            {
+                route,
+                userPublicKey: wallet.toString(),
+                wrapUnwrapSOL: true,
+            },
+            {
+                headers: { 'Content-Type': 'application/json' },
+            }
+        )
     ).data as SwapTransactionsResponse;
     return {
         setup: decodeTransactionOrNull(response.setupTransaction),
         swap: decodeTransactionOrNull(response.swapTransaction),
         cleanup: decodeTransactionOrNull(response.cleanupTransaction),
-    }
+    };
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,6 +1288,15 @@
     buffer-layout "^1.2.0"
     dotenv "10.0.0"
 
+"@solana/spl-token@0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.7.tgz#6f027f9ad8e841f792c32e50920d9d2e714fc8da"
+  integrity sha512-bKGxWTtIw6VDdCBngjtsGlKGLSmiu/8ghSt/IOYJV24BsymRbgq7r12GToeetpxmPaZYLddKwAz7+EwprLfkfg==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    buffer "^6.0.3"
+
 "@solana/spl-token@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.2.0.tgz#329bb6babb5de0f9c40035ddb1657f01a8347acd"
@@ -2039,7 +2048,7 @@ buffer@6.0.1:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buffer@6.0.3, buffer@~6.0.3:
+buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==


### PR DESCRIPTION
While trying to deploy octane to heroku, we ran into an issue with using gitpkg to install it. Since blockworks-foundation is a private team, we needed to either add an access token or an ssh to get it to download. But this got complicated since we're technically installing from a subdirectory, not the main repo.

As a (potentially temporary?) solution, I am merging this into a publicly accessible version of the repo so we can continue to use gitpkg